### PR TITLE
[BI-714] .env variables in default file are out of date

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,5 @@
-USER_ID=1001
-GROUP_ID=1001
+USER_ID=<user id of system user>
+GROUP_ID=<group id of system user>
 
 # Authentication variables
 OAUTH_CLIENT_ID=<oauth app client id>
@@ -41,6 +41,6 @@ WEB_BASE_URL=http://localhost
 REGISTERED_DOMAIN=localhost
 
 # Email relay information
-EMAIL_RELAY_HOST=<email relay host>
-EMAIL_RELAY_PORT=<email relay port>
+EMAIL_RELAY_HOST=mailhog
+EMAIL_RELAY_PORT=1025
 EMAIL_FROM=noreply@breedinginsight.org


### PR DESCRIPTION
# Brapi Clients Variables
BRAPI_CORE_URL=http://brapiserver:8080
BRAPI_PHENO_URL=http://brapiserver:8080
BRAPI_GENO_URL=http://brapiserver:8080

# Email server
EMAIL_RELAY_HOST=mailhog