### PR TITLE
[BI-1457] Docker Parameters Failure

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -27,7 +27,7 @@ services:
     image: breedinginsight/biapi:develop
     build:
       context: ./bi-api
-      dockerfile: ./bi-api/Dockerfile-dev
+      dockerfile: ./Dockerfile-dev
       args:
         HOST_USER_ID: ${USER_ID:-0}
         HOST_GROUP_ID: ${GROUP_ID:-0}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,11 +29,11 @@ services:
       - JWT_DOMAIN=${JWT_DOMAIN:-localhost}
       - JWT_SECRET=${JWT_SECRET}
       - OAUTH_CLIENT_SECRET=${OAUTH_CLIENT_SECRET}
-      - OAUTH_AUTH_URL=${OAUTH_AUTH_URL}
-      - OAUTH_TOKEN_URL=${OAUTH_TOKEN_URL}
-      - OAUTH_OPENID_ISSUER=${OAUTH_OPENID_ISSUER}
-      - OAUTH_OPENID_JWKSURI=${OAUTH_OPENID_JWKSURI}
-      - OAUTH_OPENID_USERINFOURL=${OAUTH_OPENID_USERINFOURL}
+      - OAUTH_AUTH_URL=${OAUTH_AUTH_URL:-https://sandbox.orcid.org/oauth/authorize}
+      - OAUTH_TOKEN_URL=${OAUTH_TOKEN_URL:-https://sandbox.orcid.org/oauth/token}
+      - OAUTH_OPENID_ISSUER=${OAUTH_OPENID_ISSUER:-https://sandbox.orcid.org}
+      - OAUTH_OPENID_JWKSURI=${OAUTH_OPENID_JWKSURI:-https://sandbox.orcid.org/oauth/jwks}
+      - OAUTH_OPENID_USERINFOURL=${OAUTH_OPENID_USERINFOURL:-https://sandbox.orcid.org/oauth/userinfo}
       - BRAPI_DEFAULT_URL=${BRAPI_DEFAULT_URL}
       - BRAPI_REFERENCE_SOURCE=${BRAPI_REFERENCE_SOURCE}
       - WEB_BASE_URL=${WEB_BASE_URL}


### PR DESCRIPTION
The fix applied to the TAF Github action is applied here for `bi-docker-stack` production.

The environment variables for ouath configuration point to the orcid sandbox by default.

Also, there is a minor bug fix to get the  dev environment build for bi-api working. The relative path for the Dockerfile was referencing the wrong folder.