### PR TITLE
BI-1650 - Store and fetch genotype data

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -44,3 +44,19 @@ REGISTERED_DOMAIN=localhost
 EMAIL_RELAY_HOST=mailhog
 EMAIL_RELAY_PORT=1025
 EMAIL_FROM=noreply@breedinginsight.org
+
+REDIS_URL=<redis url, ex redis://localhost:6379>
+REDIS_TIMEOUT=<timeout, default 30s>
+REDIS_SSL=<enable ssl, default false>
+
+GIGWA_HOST=<gigwa host (including port), ex http://localhost:8080>
+GIGWA_USER=<username>
+GIGWA_PASSWORD=<password>
+GIGWA_MONGO_USER=<gigwa mongodb username>
+GIGWA_MONGO_PASSWORD=<gigwa mongodb password>
+
+AWS_REGION=<aws region, default us-east-1>
+AWS_ACCESS_KEY_ID=<access key>
+AWS_SECRET_KEY=<secret>
+AWS_GENO_BUCKET=<s3 bucket for genotypic data uploads>
+AWS_S3_ENDPOINT=<s3 endpoint, default https://s3.us-east-1.amazonaws.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .env
 **/*.org
 m2/
+.env.local
+docker-compose-local.yml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Prereqs
-Docker and  Docker-compose are both required.
+Docker and Docker-compose are both required.
 
 # Configuration
 The containers are not run by the root user but by a new user and group called
@@ -45,6 +45,19 @@ docker-compose -f docker-compose.yml -f docker-compose-redis.yml -f docker-compo
 ## QA Environment
 ```
 docker-compose -f docker-compose.yml -f docker-compose-redis.yml -f docker-compose-gigwa.yml -f docker-compose-qa.yml up -d
+```
+
+## AWS S3 Configuration
+If running in production, then you will need to create an AWS IAM role to generate an access key and secret.  You will also need to define a bucket in S3 to hold the data.
+
+If you do not want to use AWS, you can utilize the localstack configuration by including `-f docker-compose-localstack.yml` in your `docker-compose up` command.
+
+Then values for the AWS parameters can be set as follows:
+
+```
+AWS_ACCESS_KEY_ID=test
+AWS_SECRET_KEY=test
+AWS_S3_ENDPOINT=http://localhost:4566
 ```
 
 ## TLS Support

--- a/README.md
+++ b/README.md
@@ -30,18 +30,21 @@ and save the Lastpass contents for "bi-api secrets" in this file.
 # Run
 
 ## Production Environment
+
+An instance of Redis and Gigwa are expected to be running.  The `.env` file must be updated to reflect where these services live.  To stand up instances of Redis or Gigwa, please refer to their respective docker-compose files (`docker-compose-redis.yml`, `docker-compose-gigwa.yml`)
+
 ```
 docker-compose up -d
 ```
 
 ## Pre-Production Environment
 ```
-docker-compose -f docker-compose.yml -f docker-compose-rc.yml up -d
+docker-compose -f docker-compose.yml -f docker-compose-redis.yml -f docker-compose-gigwa.yml -f docker-compose-rc.yml up -d
 ```
 
 ## QA Environment
 ```
-docker-compose -f docker-compose.yml -f docker-compose-qa.yml up -d
+docker-compose -f docker-compose.yml -f docker-compose-redis.yml -f docker-compose-gigwa.yml -f docker-compose-qa.yml up -d
 ```
 
 ## TLS Support
@@ -85,5 +88,5 @@ git submodule update --init --recursive
 Then run:
 
 ```
-docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+docker-compose -f docker-compose.yml -f docker-compose-redis.yml -f docker-compose-gigwa.yml -f docker-compose-dev.yml up -d
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ docker-compose up -d
 
 ## Pre-Production Environment
 ```
-docker-compose -f docker-compose.yml -f docker-compose-redis.yml -f docker-compose-gigwa.yml -f docker-compose-rc.yml up -d
+docker-compose -f docker-compose.yml -f docker-compose-redis.yml -f docker-compose-gigwa.yml -f docker-compose-qa.yml -f docker-compose-rc.yml up -d
 ```
 
 ## QA Environment

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -1,0 +1,33 @@
+version: "3.7"
+
+services:
+  biweb:
+    image: breedinginsight/biweb:ci
+    build:
+      context: ./bi-web
+      args:
+        HOST_USER_ID: ${USER_ID:-0}
+        HOST_GROUP_ID: ${GROUP_ID:-0}
+    ports:
+      - ${WEB_EXTERNAL_PORT:-8083}:8080
+  biapi:
+    image: breedinginsight/biapi:ci
+    build:
+      context: ./bi-api
+      dockerfile: ./Dockerfile-dev
+      args:
+        HOST_USER_ID: ${USER_ID:-0}
+        HOST_GROUP_ID: ${GROUP_ID:-0}
+    ports:
+      - ${API_EXTERNAL_PORT:-8090}:8081
+    environment:
+      - GITHUB_ACTOR=${GITHUB_ACTOR}
+      - GITHUB_TOKEN=${GITHUB_TOKEN}
+  brapi-server:
+    ports:
+      - ${BRAPI_SERVER_PORT:-8080}:8080
+  bidb:
+    ports:
+      - ${DB_PORT:-5432}:5432
+
+

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -11,6 +11,9 @@ services:
     ports:
       - ${WEB_EXTERNAL_PORT:-8083}:8080
   biapi:
+    depends_on:
+      - redis
+      - gigwa
     image: breedinginsight/biapi:ci
     build:
       context: ./bi-api
@@ -23,6 +26,10 @@ services:
     environment:
       - GITHUB_ACTOR=${GITHUB_ACTOR}
       - GITHUB_TOKEN=${GITHUB_TOKEN}
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
+      - REDIS_TIMEOUT=${REDIS_TIMEOUT:-30s}
+      - REDIS_SSL=${REDIS_SSL:-false}
+      - GIGWA_HOST=${GIGWA_HOST:-http://gigwa:8080}
   brapi-server:
     ports:
       - ${BRAPI_SERVER_PORT:-8080}:8080

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -55,7 +55,7 @@ services:
       - ./bi-api/src/main/resources/brapi/properties/application.properties:/home/brapi/properties/application.properties
       - ./bi-api/src/main/resources/brapi/sql/:/home/brapi/sql/
     ports:
-      - ${BRAPI_SERVER_PORT}:8080    
+      - ${BRAPI_SERVER_PORT:-8080}:8080    
   mailhog:
     ports:
       - 1025:1025

--- a/docker-compose-gigwa.yml
+++ b/docker-compose-gigwa.yml
@@ -1,0 +1,45 @@
+version: "3.7"
+
+services:
+  gigwa:
+    depends_on:
+      - mongo
+    image: breedinginsight/gigwa:2.5.2-snapshot
+    container_name: gigwa
+    ports:
+      - "5080:8080"
+    restart: always
+    environment:
+      MONGO_IP: gigwa_db
+      MONGO_PORT: 27017
+      MONGO_INITDB_ROOT_USERNAME: ${GIGWA_MONGO_USER}
+      MONGO_INITDB_ROOT_PASSWORD: ${GIGWA_MONGO_PASSWORD}
+      HOST_LOCALE: "${LANG}"
+    networks:
+      backend:
+    volumes:
+      - type: volume
+        source: gigwa_data
+        target: /usr/local/tomcat/config
+  mongo:
+    image: mongo:4.2.21
+    container_name: gigwa_db
+    restart: always
+    command: --profile 0 --slowms 60000 --storageEngine wiredTiger --wiredTigerCollectionBlockCompressor=zstd --directoryperdb --quiet
+    ports:
+      - "27017:27017"
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${GIGWA_MONGO_USER}
+      MONGO_INITDB_ROOT_PASSWORD: ${GIGWA_MONGO_PASSWORD}
+    volumes:
+      - type: volume
+        source: gigwa_mongo_data
+        target: /data/db
+    networks:
+      backend:
+
+volumes:
+  gigwa_data:
+    name: gigwa_data
+  gigwa_mongo_data:
+    name: gigwa_mongo_data

--- a/docker-compose-gigwa.yml
+++ b/docker-compose-gigwa.yml
@@ -4,13 +4,13 @@ services:
   gigwa:
     depends_on:
       - mongo
-    image: breedinginsight/gigwa:2.5.2-snapshot
-    container_name: gigwa
+    image: breedinginsight/gigwa:develop
+    container_name: ${GIGWA_CONTAINER_NAME:-gigwa}
     ports:
-      - "5080:8080"
+      - ${GIGWA_PORT:-5080}:8080
     restart: always
     environment:
-      MONGO_IP: gigwa_db
+      MONGO_IP: ${GIGWA_CONTAINER_NAME:-gigwa}_db
       MONGO_PORT: 27017
       MONGO_INITDB_ROOT_USERNAME: ${GIGWA_MONGO_USER}
       MONGO_INITDB_ROOT_PASSWORD: ${GIGWA_MONGO_PASSWORD}
@@ -23,11 +23,11 @@ services:
         target: /usr/local/tomcat/config
   mongo:
     image: mongo:4.2.21
-    container_name: gigwa_db
+    container_name: ${GIGWA_CONTAINER_NAME:-gigwa}_db
     restart: always
     command: --profile 0 --slowms 60000 --storageEngine wiredTiger --wiredTigerCollectionBlockCompressor=zstd --directoryperdb --quiet
     ports:
-      - "27017:27017"
+      - ${GIGWA_MONGO_PORT:-27017}:27017
     environment:
       MONGO_INITDB_ROOT_USERNAME: ${GIGWA_MONGO_USER}
       MONGO_INITDB_ROOT_PASSWORD: ${GIGWA_MONGO_PASSWORD}
@@ -40,6 +40,6 @@ services:
 
 volumes:
   gigwa_data:
-    name: gigwa_data
+    name: ${GIGWA_CONTAINER_NAME:-gigwa}_data
   gigwa_mongo_data:
-    name: gigwa_mongo_data
+    name: ${GIGWA_CONTAINER_NAME:-gigwa}_mongo_data

--- a/docker-compose-gigwa.yml
+++ b/docker-compose-gigwa.yml
@@ -15,6 +15,7 @@ services:
       MONGO_INITDB_ROOT_USERNAME: ${GIGWA_MONGO_USER}
       MONGO_INITDB_ROOT_PASSWORD: ${GIGWA_MONGO_PASSWORD}
       HOST_LOCALE: "${LANG}"
+      GIGWA.serversAllowedToImport: ${BRAPI_REFERENCE_SOURCE}
     networks:
       backend:
     volumes:

--- a/docker-compose-localstack.yml
+++ b/docker-compose-localstack.yml
@@ -1,0 +1,14 @@
+version: "3.7"
+
+services:
+    localstack:
+    container_name: "localstack"
+    image: localstack/localstack
+    ports:
+      - "4566:4566"
+    networks:
+      backend:
+        aliases:
+          - localstack
+    environment:
+      - HOSTNAME_EXTERNAL=localstack

--- a/docker-compose-localstack.yml
+++ b/docker-compose-localstack.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 services:
-    localstack:
+  localstack:
     container_name: "localstack"
     image: localstack/localstack
     ports:

--- a/docker-compose-qa.yml
+++ b/docker-compose-qa.yml
@@ -17,4 +17,4 @@ services:
       - GIGWA_HOST=${GIGWA_HOST:-http://gigwa:8080}
   bidb:
     ports:
-      - "5432:5432"
+      - ${DB_PORT:-5432}:5432

--- a/docker-compose-qa.yml
+++ b/docker-compose-qa.yml
@@ -5,9 +5,16 @@ services:
     image: breedinginsight/biweb:develop
   biapi:
     image: breedinginsight/biapi:develop
+    depends_on:
+      - bidb
+      - brapi-server
+      - redis
+      - gigwa
+    environment:
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
+      - REDIS_TIMEOUT=${REDIS_TIMEOUT:-30s}
+      - REDIS_SSL=${REDIS_SSL:-false}
+      - GIGWA_HOST=${GIGWA_HOST:-http://gigwa:8080}
   bidb:
     ports:
       - "5432:5432"
-  redis:
-    ports:
-      - "6379:6379"

--- a/docker-compose-rc.yml
+++ b/docker-compose-rc.yml
@@ -5,3 +5,13 @@ services:
     image: breedinginsight/biweb:rc
   biapi:
     image: breedinginsight/biapi:rc
+    depends_on:
+      - bidb
+      - brapi-server
+      - redis
+      - gigwa
+    environment:
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
+      - REDIS_TIMEOUT=${REDIS_TIMEOUT:-30s}
+      - REDIS_SSL=${REDIS_SSL:-false}
+      - GIGWA_HOST=${GIGWA_HOST:-http://gigwa:8080}

--- a/docker-compose-rc.yml
+++ b/docker-compose-rc.yml
@@ -5,13 +5,3 @@ services:
     image: breedinginsight/biweb:rc
   biapi:
     image: breedinginsight/biapi:rc
-    depends_on:
-      - bidb
-      - brapi-server
-      - redis
-      - gigwa
-    environment:
-      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
-      - REDIS_TIMEOUT=${REDIS_TIMEOUT:-30s}
-      - REDIS_SSL=${REDIS_SSL:-false}
-      - GIGWA_HOST=${GIGWA_HOST:-http://gigwa:8080}

--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -3,9 +3,9 @@ version: "3.7"
 services:
   redis:
     image: redis
-    container_name: redis
+    container_name: ${REDIS_CONTAINER_NAME:-redis}
     ports:
-      - "6379:6379"
+      - ${REDIS_PORT:-6379}:6379
     restart: always
     networks:
       backend:

--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -1,0 +1,11 @@
+version: "3.7"
+
+services:
+  redis:
+    image: redis
+    container_name: redis
+    ports:
+      - "6379:6379"
+    restart: always
+    networks:
+      backend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
     depends_on:
       - bidb
       - brapi-server
-      - redis
     environment:
       - API_INTERNAL_PORT=${API_INTERNAL_PORT:-8081}
       - DB_SERVER=${DB_SERVER:-dbserver:5432}
@@ -42,9 +41,17 @@ services:
       - EMAIL_RELAY_HOST=${EMAIL_RELAY_HOST}
       - EMAIL_RELAY_PORT=${EMAIL_RELAY_PORT}
       - EMAIL_FROM=${EMAIL_FROM}
-      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
+      - REDIS_URL=${REDIS_URL}
       - REDIS_TIMEOUT=${REDIS_TIMEOUT:-30s}
       - REDIS_SSL=${REDIS_SSL:-false}
+      - GIGWA_HOST=${GIGWA_HOST}
+      - GIGWA_USER=${GIGWA_USER}
+      - GIGWA_PASSWORD=${GIGWA_PASSWORD}
+      - AWS_REGION=${AWS_REGION:-us-east-1}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_KEY=${AWS_SECRET_KEY}
+      - AWS_GENO_BUCKET=${AWS_GENO_BUCKET}
+      - AWS_S3_ENDPOINT=${AWS_S3_ENDPOINT:-https://s3.us-east-1.amazonaws.com}
     networks:
       backend:
       protected:
@@ -77,12 +84,6 @@ services:
     ports:
       - 8025:8025
       - 1025:1025
-    networks:
-      backend:
-  redis:
-    image: redis
-    container_name: redis
-    restart: always
     networks:
       backend:
   bidb: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,8 +82,8 @@ services:
     container_name: mailhog
     restart: always
     ports:
-      - 8025:8025
-      - 1025:1025
+      - ${MAILHOG_WEB_PORT:-8025}:8025
+      - ${MAILHOG_PORT:-1025}:1025
     networks:
       backend:
   bidb: 


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1650

- Added Gigwa as a service
- Added environment variables for Gigwa
- Updated the structure of the docker-compose files to split out Gigwa and redis.  This will allow for production to not require those containers specifically (meaning production could run Gigwa and redis on their own servers/clusters)
- Updated documentation to reflect the change in the docker-compose file structure



# Dependencies
- AWS keys to connect to S3

# Testing
- Get AWS keys to connect to S3
- Verify that the application can start up, and that Gigwa starts up when running the `qa` config
- Test the card following the acceptance criteria in the card


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have made corresponding changes to documentation
