### PR TITLE
Use brapi-java-server:develop tag in docker-compose-ci.yml

### DIFF
--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -31,6 +31,7 @@ services:
       - REDIS_SSL=${REDIS_SSL:-false}
       - GIGWA_HOST=${GIGWA_HOST:-http://gigwa:8080}
   brapi-server:
+    image: breedinginsight/brapi-java-server:develop
     ports:
       - ${BRAPI_SERVER_PORT:-8080}:8080
   bidb:


### PR DESCRIPTION
Without this override, the [custom TAF workflow](https://github.com/Breeding-Insight/taf/blob/develop/.github/workflows/test-branch.yml) uses the `brapi-java-server:latest` tag which is only updated each major release, at time of writing it is 8 months old and has started causing TAF failures.

Notes: 
- The daily TAF workflow uses docker-compose-qa.yml which already specifies the `develop` tag. 
- The custom TAF workflow needs to use docker-compose-ci.yml instead because it allows building docker images for bi-api and bi-web from the user provided feature or bug branches. 
- Because we compare the daily runs of TAF with the custom runs of TAF, I think it makes sense to use the same brapi-java-server image for both, hence this change.
- Because the change is in docker-compose-ci.yml, I don't think this will impact production, QA or release test deployments.