### PR TITLE
BI-1896 - Automate Obtaining and Renewing Let's Encrypt TLS Certificates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,6 +140,11 @@ services:
       - type: volume
         source: proxy_config
         target: /etc/nginx/conf.d
+    healthcheck:
+      test: ["CMD-SHELL", "curl -so /dev/null http://localhost/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       upstream:
       protected:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,6 @@ services:
       dockerfile: biproxy.docker
       context: ./proxy
       args:
-        - CERT_REGISTRATION_EMAIL=${CERT_REGISTRATION_EMAIL}
         - REGISTERED_DOMAIN=${REGISTERED_DOMAIN:-localhost}
         - API_IP=biapi:8081
         - WEB_IP=biweb:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,6 +124,7 @@ services:
       dockerfile: biproxy.docker
       context: ./proxy
       args:
+        - CERT_REGISTRATION_EMAIL=${CERT_REGISTRATION_EMAIL}
         - REGISTERED_DOMAIN=${REGISTERED_DOMAIN:-localhost}
         - API_IP=biapi:8081
         - WEB_IP=biweb:8080

--- a/proxy/biproxy.docker
+++ b/proxy/biproxy.docker
@@ -5,6 +5,7 @@ FROM nginx@sha256:a98c2360dcfe44e9987ed09d59421bb654cb6c4abe50a92ec9c912f2524614
 RUN echo "deb http://ftp.debian.org/debian buster-backports main" >> /etc/apt/sources.list
 RUN apt-get update
 RUN apt install -y python-certbot-nginx -t buster-backports
+ARG CERT_REGISTRATION_EMAIL
 ARG REGISTERED_DOMAIN
 ARG API_IP
 ARG WEB_IP
@@ -62,3 +63,29 @@ server {\n\
 }\n"\
 >> breedinginsight.net.conf
 RUN rm /etc/nginx/conf.d/default.conf
+
+# Obtain cert (will renew if it already exists and is close to expiry).
+# If CERT_REGISTRATION_EMAIL is null or empty, register without email (not recommended).
+RUN if [[ -n $CERT_REGISTRATION_EMAIL ]]; then \
+      certbot run --nginx --non-interactive --domain ${REGISTERED_DOMAIN} --email ${CERT_REGISTRATION_EMAIL} --agree-tos  --keep-until-expiring --no-eff-email; \
+    else \
+      certbot run --nginx --non-interactive --domain ${REGISTERED_DOMAIN} --register-unsafely-without-email --agree-tos  --keep-until-expiring; \
+    fi
+
+# Install supercronic-linux-amd64.
+# Latest releases available at https://github.com/aptible/supercronic/releases.
+ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.26/supercronic-linux-amd64 \
+    SUPERCRONIC=supercronic-linux-amd64 \
+    SUPERCRONIC_SHA1SUM=7a79496cf8ad899b99a719355d4db27422396735
+
+RUN curl -fsSLO "$SUPERCRONIC_URL" \
+ && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
+ && chmod +x "$SUPERCRONIC" \
+ && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
+ && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
+
+ # Copy crontab.
+ COPY crontab .
+
+# Point supercronic to contab.
+RUN supercronic crontab

--- a/proxy/biproxy.docker
+++ b/proxy/biproxy.docker
@@ -4,8 +4,7 @@ FROM nginx@sha256:a98c2360dcfe44e9987ed09d59421bb654cb6c4abe50a92ec9c912f2524614
 
 RUN echo "deb http://ftp.debian.org/debian buster-backports main" >> /etc/apt/sources.list
 RUN apt-get update
-RUN apt install -y python-certbot-nginx -t buster-backports
-ARG CERT_REGISTRATION_EMAIL
+RUN apt install -y cron python-certbot-nginx -t buster-backports
 ARG REGISTERED_DOMAIN
 ARG API_IP
 ARG WEB_IP
@@ -63,21 +62,3 @@ server {\n\
 }\n"\
 >> breedinginsight.net.conf
 RUN rm /etc/nginx/conf.d/default.conf
-
-# Install supercronic-linux-amd64.
-# Latest releases available at https://github.com/aptible/supercronic/releases.
-ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.26/supercronic-linux-amd64 \
-    SUPERCRONIC=supercronic-linux-amd64 \
-    SUPERCRONIC_SHA1SUM=7a79496cf8ad899b99a719355d4db27422396735
-
-RUN curl -fsSLO "$SUPERCRONIC_URL" \
- && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
- && chmod +x "$SUPERCRONIC" \
- && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
- && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
-
-# Copy crontab.
-COPY crontab .
-
-# Point supercronic to contab.
-RUN supercronic crontab

--- a/proxy/biproxy.docker
+++ b/proxy/biproxy.docker
@@ -84,8 +84,8 @@ RUN curl -fsSLO "$SUPERCRONIC_URL" \
  && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
  && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
 
- # Copy crontab.
- COPY crontab .
+# Copy crontab.
+COPY crontab .
 
 # Point supercronic to contab.
 RUN supercronic crontab

--- a/proxy/biproxy.docker
+++ b/proxy/biproxy.docker
@@ -64,14 +64,6 @@ server {\n\
 >> breedinginsight.net.conf
 RUN rm /etc/nginx/conf.d/default.conf
 
-# Obtain cert (will renew if it already exists and is close to expiry).
-# If CERT_REGISTRATION_EMAIL is null or empty, register without email (not recommended).
-RUN if [ -n "$CERT_REGISTRATION_EMAIL" ]; then \
-      certbot run --nginx --non-interactive --domain ${REGISTERED_DOMAIN} --email ${CERT_REGISTRATION_EMAIL} --agree-tos  --keep-until-expiring --no-eff-email; \
-    else \
-      certbot run --nginx --non-interactive --domain ${REGISTERED_DOMAIN} --register-unsafely-without-email --agree-tos  --keep-until-expiring; \
-    fi
-
 # Install supercronic-linux-amd64.
 # Latest releases available at https://github.com/aptible/supercronic/releases.
 ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.26/supercronic-linux-amd64 \

--- a/proxy/biproxy.docker
+++ b/proxy/biproxy.docker
@@ -66,7 +66,7 @@ RUN rm /etc/nginx/conf.d/default.conf
 
 # Obtain cert (will renew if it already exists and is close to expiry).
 # If CERT_REGISTRATION_EMAIL is null or empty, register without email (not recommended).
-RUN if [[ -n "$CERT_REGISTRATION_EMAIL" ]]; then \
+RUN if [ -n "$CERT_REGISTRATION_EMAIL" ]; then \
       certbot run --nginx --non-interactive --domain ${REGISTERED_DOMAIN} --email ${CERT_REGISTRATION_EMAIL} --agree-tos  --keep-until-expiring --no-eff-email; \
     else \
       certbot run --nginx --non-interactive --domain ${REGISTERED_DOMAIN} --register-unsafely-without-email --agree-tos  --keep-until-expiring; \

--- a/proxy/biproxy.docker
+++ b/proxy/biproxy.docker
@@ -66,7 +66,7 @@ RUN rm /etc/nginx/conf.d/default.conf
 
 # Obtain cert (will renew if it already exists and is close to expiry).
 # If CERT_REGISTRATION_EMAIL is null or empty, register without email (not recommended).
-RUN if [[ -n $CERT_REGISTRATION_EMAIL ]]; then \
+RUN if [[ -n "$CERT_REGISTRATION_EMAIL" ]]; then \
       certbot run --nginx --non-interactive --domain ${REGISTERED_DOMAIN} --email ${CERT_REGISTRATION_EMAIL} --agree-tos  --keep-until-expiring --no-eff-email; \
     else \
       certbot run --nginx --non-interactive --domain ${REGISTERED_DOMAIN} --register-unsafely-without-email --agree-tos  --keep-until-expiring; \

--- a/proxy/biproxy.docker
+++ b/proxy/biproxy.docker
@@ -62,3 +62,7 @@ server {\n\
 }\n"\
 >> breedinginsight.net.conf
 RUN rm /etc/nginx/conf.d/default.conf
+
+# Start cron service and run init scripts for nginx.
+# (The default command for this image is `/docker-entrypoint.sh nginx -g 'daemon off;'`.)
+CMD service cron start && /docker-entrypoint.sh nginx -g 'daemon off;'

--- a/proxy/crontab
+++ b/proxy/crontab
@@ -1,0 +1,2 @@
+# Run cerbot renew non-interactively daily at 2:24.
+24 2 * * * certbot renew --quiet

--- a/proxy/crontab
+++ b/proxy/crontab
@@ -1,2 +1,0 @@
-# Run cerbot renew non-interactively daily at 2:24.
-24 2 * * * certbot renew --quiet


### PR DESCRIPTION
Description:
[Jira Story](https://breedinginsight.atlassian.net/browse/BI-1896).

Related changes in breedbase_configs: https://github.com/Breeding-Insight/breedbase_configs/pull/30.

Changes:
- Added healthcheck for the nginx container.
- Added cron to the nginx container.
- Altered the CMD of the nginx container to also start the cron daemon.
- Modified the Jenkins "Deploy to Rel Test" config to obtain a cert.

Note on certbot run command:
- if there is no cert, it will obtain one
- if there is an expiring cert, it will renew
- if there is a non-expiring cert, it will do nothing

Dependencies/Deployment:
The changes made in this PR will ensure cron is installed and running on the biproxy container. When you install `certbot` it automatically creates a crontab entry for renewal, however, that cron job won't do anything until a cert is actually installed. There are two options for this:

1. Manually run certbot to obtain the initial cert.
2. Add the `certbot run` command to the end of any Jenkins deploy jobs we want to automate. I tested adding the following to the end of the Jenkins step that starts up bi-docker-stack for the "Deploy to Rel-Test" job:
```shell
# Run certbot once nginx is healthy.
echo "Waiting for biproxy to be healthy"
while [ "$(docker inspect -f "{{.State.Health.Status}}" "biproxy")" != "healthy" ]; do sleep 1; done
echo "biproxy is healthy! Running certbot!"

docker exec -d biproxy certbot run --nginx --non-interactive --domain $REGISTERED_DOMAIN --email bidevteam@cornell.edu --agree-tos --keep-until-expiring --no-eff-email --redirect;
```