### PR TITLE
[BI-1880] - added BRAPI_POST_CHUNK to .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -24,6 +24,9 @@ API_INTERNAL_TEST_PORT=8082
 
 BRAPI_READ_TIMEOUT=60m
 
+# Max number of records to POST to the BrAPI service per request
+POST_CHUNK_SIZE=1000
+
 # BrAPI Server Variables
 BRAPI_SERVER_PORT=8080
 


### PR DESCRIPTION
I added `BRAPI_POST_CHUNK` to the .env.template file. This variable can be set in the .env for each deployed instance, but the default has been changed from 100 to 1000 by the changes in [this PR](https://github.com/Breeding-Insight/bi-api/pull/287).