### PR TITLE
BI-2019 - Pedigree Viewer Not Rendering

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,8 @@ services:
     networks:
       backend:
         aliases:
-          - dbserver  
+          - dbserver
+    shm_size: 2g
   # biwaf:
   #   image: franbuehler/modsecurity-crs-rp
   #   container_name: waf


### PR DESCRIPTION
Jira Story: https://breedinginsight.atlassian.net/browse/BI-2019

I increased the shared memory size for the postgres container from the default 64kiB to 2GiB.

[Docker shm_size docs](https://docs.docker.com/compose/compose-file/05-services/#shm_size)

[Related PR on bi-api](https://github.com/Breeding-Insight/bi-api/pull/324)