### PR TITLE
merge v0.9 back into develop

### DIFF
--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   redis:
-    image: redis
+    image: redis:7.2.0
     container_name: ${REDIS_CONTAINER_NAME:-redis}
     ports:
       - ${REDIS_PORT:-6379}:6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
   biapi:
     container_name: biapi
     image: breedinginsight/biapi:latest
+    restart: always
     depends_on:
       - bidb
       - brapi-server
@@ -61,6 +62,7 @@ services:
   brapi-server:
     image: breedinginsight/brapi-java-server:latest
     container_name: brapi-server
+    restart: always
     depends_on:
       - bidb
     environment:
@@ -95,6 +97,7 @@ services:
       POSTGRES_DB: 'bidb'
       POSTGRES_PASSWORD: ${DB_PASSWORD}
     container_name: bidb
+    restart: always
     volumes:
       - type: volume
         source: biapi_data
@@ -123,6 +126,7 @@ services:
   biproxy:
     container_name: biproxy    
     image: biproxy
+    restart: always
     build:
       dockerfile: biproxy.docker
       context: ./proxy


### PR DESCRIPTION
I manually created this branch to avoid some messy git history I accidentally brought into the release/v0.9 branch.

It replaces https://github.com/Breeding-Insight/bi-docker-stack/pull/42.