### PR TITLE
BI-2118 - Fixed biproxy Docker Build Failure

### DIFF
--- a/proxy/biproxy.docker
+++ b/proxy/biproxy.docker
@@ -1,10 +1,8 @@
 #FROM nginx:1.20
-#temporary fix to use specific nginx image
-FROM nginx@sha256:a98c2360dcfe44e9987ed09d59421bb654cb6c4abe50a92ec9c912f252461483
+FROM nginx:stable-bookworm
 
-RUN echo "deb http://ftp.debian.org/debian buster-backports main" >> /etc/apt/sources.list
 RUN apt-get update
-RUN apt install -y cron python-certbot-nginx -t buster-backports
+RUN apt install -y cron python3-certbot-nginx
 ARG REGISTERED_DOMAIN
 ARG API_IP
 ARG WEB_IP


### PR DESCRIPTION
## Description

Jira Story: [BI-2118](https://breedinginsight.atlassian.net/browse/BI-2118)

The `biproxy` container was being built from an old debian base image, I don't know why. It seemed like the apt repositories it was trying to access are no longer available.

I updated the `biproxy` Dockerfile (biproxy.docker) to use a debian stable base image. I tested it locally to confirm it works. I also had to update the `python-certbot-nginx` apt package to `python3-certbot-nginx`, I believe this name has been changed to indicate that python 2 is not supported.

[BI-2118]: https://breedinginsight.atlassian.net/browse/BI-2118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

# Testing
- Ensure that [this TAF run](https://github.com/Breeding-Insight/taf/actions/runs/8991666424) doesn't fail during the image build.
- Run bi-docker-stack locally and ensure the proxy functions as expected. Message me if you need help getting it configured locally.