### PR TITLE
[BI-2113] Add nginx rule to route LetsEncrypt request to nginx web root

### DIFF
--- a/proxy/biproxy.docker
+++ b/proxy/biproxy.docker
@@ -33,6 +33,9 @@ upstream web {\n\
 server {\n\
     server_name ${REGISTERED_DOMAIN};\n\
 \n\
+    location /.well-known/acme-challenge/ {\n\
+        root /usr/share/nginx/html;\n\
+    }\n\    
     location /v1 {\n\
         proxy_pass http://api;\n\
         include /etc/nginx/conf.d/proxy-headers.conf;\n\


### PR DESCRIPTION
# Description
**Story:** [BI-2113 Sandbox to EC2](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-2113)

### Context
1. A developer(or Jenkins job) is either making a fresh install of bi-docker-stack or is installing updates pulled from a remote branch.
2. LetsEncrypt needs to verify ownership of the domain and server to either issue a new certificate (new install) or renew an existing certificate (updates installed).
3. In the nginx biproxy container the certbot client is called to certify ownership.

### Expected Behavior
LetsEncrypt confirms ownership successfully and the Certbot client automatically installs the certificate and makes any necessary changes to the nginx rules to route requests on port 443 if this is a fresh install.

### Actual Behavior
The verification of ownership fails and a certificate is not issued. Certbot installs a temporary file in the nginx web root folder with the path /.well-known/acme-challenge, and LetsEncrypt confirms ownership by finding this file when it makes a GET request on port 80 for /.well-known/acme-challenge/<TOKEN>. Nginx is configured to pass through all requests on PORT 80 upstream to biweb, so LetsEncrypt never finds it file, and ownership verification fails.

### Solution
A rule was added to the biproxy nginx config to route requests made on /.well-known/acme-challenge, port 80 to the nginx web root. 

# Dependencies
none

# Testing
1. Create a fresh install of bi-docker-stack by cloning the repo and following the installation instructions
2. Start the docker stack via docker compose up
3. Docker exec into the biproxy container and run certbot to verify ownership and install a vlaid certificate (you may need to rm the certs docker volume prior to spinning up the stack if it was used before)
4. Confim that Certbot succeeded in installing the certificate


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_