### PR TITLE
BI-2941: Increase proxy upload size limit

### DIFF
--- a/proxy/biproxy.docker
+++ b/proxy/biproxy.docker
@@ -16,7 +16,7 @@ proxy_http_version 1.1;\n\
 proxy_set_header Connection \"\";\n\
 proxy_buffering off;\n\
 proxy_request_buffering off;\n\
-client_max_body_size 100M;\n\
+client_max_body_size 1G;\n\
 proxy_read_timeout 36000s;\n\
 proxy_redirect off;\n"\
 >> proxy-headers.conf


### PR DESCRIPTION
## Summary
Increased the Nginx reverse proxy upload limit from `100M` to `1G`.

## Reason
Genotype VCF files larger than 100 MB were being rejected by `biproxy` with a `413 Request Entity Too Large` response before the request reached `bi-api`.

The backend supports VCF files up to 800 MB, so the proxy limit was increased to 1 GB to allow for multipart request overhead while keeping the backend as the actual file-size enforcement layer.

## Validation
- Confirmed the QA proxy logs showed:
  `client intended to send too large body`
- Confirmed the active proxy configuration was:
  `client_max_body_size 100M;`
- Updated `proxy/biproxy.docker` to:
  `client_max_body_size 1G;`